### PR TITLE
Number formatting bugs

### DIFF
--- a/src/components/Chloropleth.jsx
+++ b/src/components/Chloropleth.jsx
@@ -277,7 +277,7 @@ const Chloropleth = (props) => {
 
   const formatValue = useMemo(() =>
     percentage
-      ? v => `${v.toFixed(1)}%`
+      ? v => `${Number.isInteger(v) ? v : v.toFixed(1)}%`
       : v => v.toFixed(2)
   , [percentage])
 

--- a/src/components/MultiLinePlot.jsx
+++ b/src/components/MultiLinePlot.jsx
@@ -122,7 +122,8 @@ const MultiLinePlot = props => {
         tickFormatter: value => {
           if (value === 0) return '0%'
           if (value >= 100) return '100%'
-          return `${parseFloat(value).toPrecision(2)}%`
+          if (!Number.isInteger(value)) return `${value.toFixed(1)}%`
+          return `${value}%`
         }
       }
     }


### PR DESCRIPTION
* map scalebar: only fix precision of non-integer percentages
* chart y-axis: used fixed precision over significant digits for non-integer percentages