### PR TITLE
Location search: allow input to be upper case

### DIFF
--- a/src/components/LocationFilter.jsx
+++ b/src/components/LocationFilter.jsx
@@ -25,7 +25,7 @@ const Search = ({ onSelect, items, value, onChange, onClose }) => {
   const isMobile = useMobile()
 
   const _onChange = useCallback((e) => {
-    onChange(e.target.value.toLowerCase())
+    onChange(e.target.value)
   }, [onChange])
 
   const inputRef = useRef()


### PR DESCRIPTION
Tiny change. It feels a bit weird to type a postcode and have it forced to lower case in the text-box "ne22", etc. As far as I can tell I haven't broken anything with this.